### PR TITLE
Nice shutdown + Win fix

### DIFF
--- a/Linux/Headers/AfkListener.hpp
+++ b/Linux/Headers/AfkListener.hpp
@@ -19,13 +19,14 @@ private:
     std::unique_ptr<std::thread> _eventListener;
     std::unique_ptr<FocusEventEmitter> _eventEmitter = std::make_unique<FocusEventEmitter>();
     std::atomic<bool> _isRunning;
+    std::atomic<bool> _sigReceived;
 
     void EventListener() override final;
 
     void OnAfk(const std::chrono::milliseconds &timeSinceEpoch) const override final;
 
 public:
-    void Run(int triggerAfkInSecond) override final;
+    void Run(int triggerAfkInSecond, std::atomic<bool> &sigReceived) override final;
 
     AfkListener();
 

--- a/Linux/Headers/AfkListener.hpp
+++ b/Linux/Headers/AfkListener.hpp
@@ -10,6 +10,7 @@
 #include <FocusEventEmitter.hpp>
 #include <X11/Xlib.h>
 #include <X11/extensions/scrnsaver.h>
+#include <atomic>
 
 class AfkListener : public IAfkListener {
 private:
@@ -17,6 +18,7 @@ private:
     int _triggerAfkInSecond;
     std::unique_ptr<std::thread> _eventListener;
     std::unique_ptr<FocusEventEmitter> _eventEmitter = std::make_unique<FocusEventEmitter>();
+    std::atomic<bool> _isRunning;
 
     void EventListener() override final;
 
@@ -24,6 +26,10 @@ private:
 
 public:
     void Run(int triggerAfkInSecond) override final;
+
+    AfkListener();
+
+    virtual ~AfkListener();
 };
 
 

--- a/Linux/Headers/ContextAgent.hpp
+++ b/Linux/Headers/ContextAgent.hpp
@@ -19,6 +19,7 @@ private:
     std::unique_ptr<std::thread> _eventListener;
     std::unique_ptr<FocusEventEmitter> _eventEmitter = std::make_unique<FocusEventEmitter>();
     std::atomic<bool> _isRunning;
+    std::atomic<bool> _sigReceived;
 
     void EventListener() override final;
 
@@ -27,7 +28,7 @@ private:
     static int x11Errorhandler(Display *display, XErrorEvent *error);
 
 public:
-    void Run() override final;
+    void Run(std::atomic<bool> &sigReceived) override final;
 
     void OnContextChanged(const std::string &processName, const std::string &windowTitle) const override final;
 

--- a/Linux/Headers/ContextAgent.hpp
+++ b/Linux/Headers/ContextAgent.hpp
@@ -10,6 +10,7 @@
 #include "FocusEventEmitter.hpp"
 #include <X11/Xlib.h>
 #include <X11/Xmu/WinUtil.h>
+#include <atomic>
 
 class ContextAgent : public IContextAgent {
 private:
@@ -17,6 +18,7 @@ private:
     Window _window;
     std::unique_ptr<std::thread> _eventListener;
     std::unique_ptr<FocusEventEmitter> _eventEmitter = std::make_unique<FocusEventEmitter>();
+    std::atomic<bool> _isRunning;
 
     void EventListener() override final;
 
@@ -28,6 +30,10 @@ public:
     void Run() override final;
 
     void OnContextChanged(const std::string &processName, const std::string &windowTitle) const override final;
+
+    ContextAgent();
+
+    virtual ~ContextAgent();
 };
 
 #endif //FOCUS_CLIENT_WINDOWSCONTEXTAGENT_HPP

--- a/Linux/Sources/ContextAgent.cpp
+++ b/Linux/Sources/ContextAgent.cpp
@@ -7,6 +7,7 @@
 #include <FocusSerializer.hpp>
 #include <spdlog/spdlog.h>
 #include <iostream>
+#include <X11/Xutil.h>
 #include "ContextAgent.hpp"
 #include "FocusContextEventPayload.pb.h"
 
@@ -28,7 +29,7 @@ std::tuple<std::string, std::string> ContextAgent::getWindowInfo() {
             Window parent = _window;
             Window root = None;
             Window *children;
-            unsigned int nchild;
+            unsigned int nchild = 0;
             Status s1;
             while (parent != root) {
                 _window = parent;
@@ -47,10 +48,11 @@ std::tuple<std::string, std::string> ContextAgent::getWindowInfo() {
             if (!_xerror && s2) {
                 int count = 0;
                 int result;
-                char **list = NULL;
+                char **list = nullptr;
                 result = XmbTextPropertyToTextList(_display, &prop, &list, &count);
                 if (result == Success) {
                     std::string windowName(list[0]);
+                    XFreeStringList(list);
                     Status s3;
                     XClassHint *classWindow;
                     classWindow = XAllocClassHint();
@@ -60,6 +62,9 @@ std::tuple<std::string, std::string> ContextAgent::getWindowInfo() {
                     s3 = XGetClassHint(_display, _window, classWindow);
                     if (_xerror || s3) {
                         std::string processName(classWindow->res_class);
+                        XFree(classWindow->res_class);
+                        XFree(classWindow->res_name);
+                        XFree(classWindow);
                         return std::make_tuple(windowName, processName);
                     } else {
                         spdlog::get("logger")->error("XGetClassHint error");
@@ -77,11 +82,11 @@ std::tuple<std::string, std::string> ContextAgent::getWindowInfo() {
 
 void ContextAgent::Run() {
     setlocale(LC_ALL, "");
-    _display = XOpenDisplay(NULL);
-    if (_display == NULL) {
+    _display = XOpenDisplay(nullptr);
+    if (_display == nullptr) {
         spdlog::get("logger")->error("Failed to connect to X Server");
     }
-    if (_display != NULL) {
+    if (_display != nullptr) {
         _eventListener = std::make_unique<std::thread>(std::bind(&ContextAgent::EventListener, this));
     }
 }
@@ -92,7 +97,7 @@ void ContextAgent::EventListener() {
 
     XSetErrorHandler(x11Errorhandler);
 
-    while (true) {
+    while (_isRunning) {
         std::tuple<std::string, std::string> info = getWindowInfo();
         std::string windowsTitle = std::get<0>(info);
         std::string processName = std::get<1>(info);
@@ -113,4 +118,14 @@ void ContextAgent::OnContextChanged(const std::string &processName, const std::s
     Focus::Event event = FocusSerializer::CreateEventFromContext("ContextChanged", context);
 
     _eventEmitter->Emit("NewEvent", event);
+}
+
+ContextAgent::~ContextAgent() {
+    _isRunning = false;
+    _eventListener->join();
+    XCloseDisplay(_display);
+}
+
+ContextAgent::ContextAgent() {
+    _isRunning = true;
 }

--- a/Linux/main.cpp
+++ b/Linux/main.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <spdlog/spdlog.h>
+#include <condition_variable>
 #include "FocusDaemon.hpp"
 
 std::mutex mtx;
@@ -37,7 +38,7 @@ int main(const int ac, const char **av) {
     spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [thread %t] [%l]\t\t: %v");
 
     FocusDaemon daemon;
-    daemon.Run("daemon.config");
+    daemon.Run("daemon.config", sigReceived);
 
     std::unique_lock<std::mutex> lck(mtx);
     cv.wait(lck);

--- a/Linux/main.cpp
+++ b/Linux/main.cpp
@@ -5,32 +5,42 @@
 #include <spdlog/spdlog.h>
 #include "FocusDaemon.hpp"
 
+std::mutex mtx;
+std::condition_variable cv;
+std::atomic<bool> sigReceived;
+
 void exitProgram(int sig) {
-	spdlog::set_pattern("\t*****  %v  *****");
-	spdlog::get("logger")->info("End of program");
-	spdlog::get("logger")->flush();
-	spdlog::drop_all();
+    sigReceived = true;
+    spdlog::set_pattern("\t*****  %v  *****");
+    spdlog::get("logger")->info("End of program");
+    spdlog::get("logger")->flush();
+    spdlog::drop_all();
+    std::unique_lock<std::mutex> lck(mtx);
+    cv.notify_all();
 }
 
 int main(const int ac, const char **av) {
-	signal(SIGABRT, &exitProgram);
-	signal(SIGTERM, &exitProgram);
-	signal(SIGINT, &exitProgram);
+    signal(SIGABRT, &exitProgram);
+    signal(SIGTERM, &exitProgram);
+    signal(SIGINT, &exitProgram);
+    sigReceived = false;
 
-	auto console = spdlog::stdout_color_mt("console");
-	std::vector<spdlog::sink_ptr> sinks;
-	sinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_mt>());
-	sinks.push_back(std::make_shared<spdlog::sinks::rotating_file_sink_mt>("logs/logs.txt", 1048576 * 5, 3));
-	auto combined_logger = std::make_shared<spdlog::logger>("logger", begin(sinks), end(sinks));
-	spdlog::register_logger(combined_logger);
+    auto console = spdlog::stdout_color_mt("console");
+    std::vector<spdlog::sink_ptr> sinks;
+    sinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_mt>());
+    sinks.push_back(std::make_shared<spdlog::sinks::rotating_file_sink_mt>("logs/logs.txt", 1048576 * 5, 3));
+    auto combined_logger = std::make_shared<spdlog::logger>("logger", begin(sinks), end(sinks));
+    spdlog::register_logger(combined_logger);
 
-	spdlog::set_pattern("\t*****  %v  *****");
-	spdlog::get("logger")->info("Starting Focus daemon on Linux Platform");
-	spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [thread %t] [%l]\t\t: %v");
+    spdlog::set_pattern("\t*****  %v  *****");
+    spdlog::get("logger")->info("Starting Focus daemon on Linux Platform");
+    spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [thread %t] [%l]\t\t: %v");
 
-	FocusDaemon daemon;
-	daemon.Run("daemon.config");
+    FocusDaemon daemon;
+    daemon.Run("daemon.config");
 
-	exitProgram(0);
-	return (0);
+    std::unique_lock<std::mutex> lck(mtx);
+    cv.wait(lck);
+
+    return (0);
 }

--- a/MacOs/Headers/AfkListener.hpp
+++ b/MacOs/Headers/AfkListener.hpp
@@ -13,6 +13,7 @@ class AfkListener : public IAfkListener {
 private:
     int _triggerAfkInSecond;
     std::unique_ptr<std::thread> _eventListener;
+    std::atomic<bool> _isRunning = true;
     std::unique_ptr<FocusEventEmitter> _eventEmitter = std::make_unique<FocusEventEmitter>();
 
     void EventListener() override final;
@@ -21,6 +22,8 @@ private:
 
 public:
     void Run(int triggerAfkInSecond) override final;
+
+    virtual ~AfkListener();
 };
 
 

--- a/MacOs/Headers/AfkListener.hpp
+++ b/MacOs/Headers/AfkListener.hpp
@@ -8,6 +8,7 @@
 #include <IAfkListener.hpp>
 #include <thread>
 #include <FocusEventEmitter.hpp>
+#include <atomic>
 
 class AfkListener : public IAfkListener {
 private:

--- a/MacOs/Headers/AfkListener.hpp
+++ b/MacOs/Headers/AfkListener.hpp
@@ -13,7 +13,7 @@ class AfkListener : public IAfkListener {
 private:
     int _triggerAfkInSecond;
     std::unique_ptr<std::thread> _eventListener;
-    std::atomic<bool> _isRunning = true;
+    std::atomic<bool> _isRunning;
     std::unique_ptr<FocusEventEmitter> _eventEmitter = std::make_unique<FocusEventEmitter>();
 
     void EventListener() override final;
@@ -22,6 +22,8 @@ private:
 
 public:
     void Run(int triggerAfkInSecond) override final;
+
+    AfkListener();
 
     virtual ~AfkListener();
 };

--- a/MacOs/Headers/AfkListener.hpp
+++ b/MacOs/Headers/AfkListener.hpp
@@ -15,6 +15,7 @@ private:
     int _triggerAfkInSecond;
     std::unique_ptr<std::thread> _eventListener;
     std::atomic<bool> _isRunning;
+    std::atomic<bool> _sigReceived;
     std::unique_ptr<FocusEventEmitter> _eventEmitter = std::make_unique<FocusEventEmitter>();
 
     void EventListener() override final;
@@ -22,7 +23,7 @@ private:
     void OnAfk(const std::chrono::milliseconds &timeSinceEpoch) const override final;
 
 public:
-    void Run(int triggerAfkInSecond) override final;
+    void Run(int triggerAfkInSecond, std::atomic<bool> &sigReceived) override final;
 
     AfkListener();
 

--- a/MacOs/Headers/ContextAgent.hpp
+++ b/MacOs/Headers/ContextAgent.hpp
@@ -13,13 +13,14 @@ class ContextAgent : public IContextAgent {
 private:
     std::unique_ptr<std::thread> _eventListener;
     std::atomic<bool> _isRunning;
+    std::atomic<bool> _sigReceived;
     std::unique_ptr<FocusEventEmitter> _eventEmitter = std::make_unique<FocusEventEmitter>();
 
     void EventListener() override final;
 
 
 public:
-    void Run() override final;
+    void Run(std::atomic<bool> &sigReceived) override final;
 
     void OnContextChanged(const std::string &processName, const std::string &windowTitle) const override final;
 

--- a/MacOs/Headers/ContextAgent.hpp
+++ b/MacOs/Headers/ContextAgent.hpp
@@ -12,7 +12,7 @@
 class ContextAgent : public IContextAgent {
 private:
     std::unique_ptr<std::thread> _eventListener;
-    std::atomic<bool> _isRunning = true;
+    std::atomic<bool> _isRunning;
     std::unique_ptr<FocusEventEmitter> _eventEmitter = std::make_unique<FocusEventEmitter>();
 
     void EventListener() override final;
@@ -22,6 +22,8 @@ public:
     void Run() override final;
 
     void OnContextChanged(const std::string &processName, const std::string &windowTitle) const override final;
+
+    ContextAgent();
 
     virtual ~ContextAgent();
 };

--- a/MacOs/Headers/ContextAgent.hpp
+++ b/MacOs/Headers/ContextAgent.hpp
@@ -12,6 +12,7 @@
 class ContextAgent : public IContextAgent {
 private:
     std::unique_ptr<std::thread> _eventListener;
+    std::atomic<bool> _isRunning = true;
     std::unique_ptr<FocusEventEmitter> _eventEmitter = std::make_unique<FocusEventEmitter>();
 
     void EventListener() override final;
@@ -20,7 +21,9 @@ private:
 public:
     void Run() override final;
 
-	void OnContextChanged(const std::string &processName, const std::string &windowTitle) const override final;
+    void OnContextChanged(const std::string &processName, const std::string &windowTitle) const override final;
+
+    virtual ~ContextAgent();
 };
 
 #endif //FOCUS_CLIENT_WINDOWSCONTEXTAGENT_HPP

--- a/MacOs/Sources/AfkListener.cpp
+++ b/MacOs/Sources/AfkListener.cpp
@@ -52,4 +52,9 @@ void AfkListener::OnAfk(const std::chrono::milliseconds &timeSinceEpoch) const {
 AfkListener::~AfkListener() {
     _isRunning = false;
     _eventListener->join();
+    spdlog::get("logger")->info("Afk Listener is shutting down");
+}
+
+AfkListener::AfkListener() {
+    _isRunning = true;
 }

--- a/MacOs/Sources/AfkListener.cpp
+++ b/MacOs/Sources/AfkListener.cpp
@@ -52,7 +52,6 @@ void AfkListener::OnAfk(const std::chrono::milliseconds &timeSinceEpoch) const {
 AfkListener::~AfkListener() {
     _isRunning = false;
     _eventListener->join();
-    spdlog::get("logger")->info("Afk Listener is shutting down");
 }
 
 AfkListener::AfkListener() {

--- a/MacOs/Sources/AfkListener.cpp
+++ b/MacOs/Sources/AfkListener.cpp
@@ -17,7 +17,7 @@ void AfkListener::EventListener() {
     bool afk = false;
     double lastInputSince = 0;
 
-    while (true) {
+    while (_isRunning) {
         lastInputSince = CGEventSourceSecondsSinceLastEventType(kCGEventSourceStateHIDSystemState, kCGAnyInputEventType);
         if (lastInputSince < _triggerAfkInSecond) {
             afk = false;
@@ -47,4 +47,9 @@ void AfkListener::OnAfk(const std::chrono::milliseconds &timeSinceEpoch) const {
 
     _eventEmitter->Emit("NewEvent", event);
 
+}
+
+AfkListener::~AfkListener() {
+    _isRunning = false;
+    _eventListener->join();
 }

--- a/MacOs/Sources/ContextAgent.cpp
+++ b/MacOs/Sources/ContextAgent.cpp
@@ -19,7 +19,7 @@ void ContextAgent::EventListener() {
     std::string cmd = "osascript ./printAppTitle.scpt";
     std::string oldProcessName;
     std::string oldWindowsTitle;
-    while (true) {
+    while (_isRunning) {
         std::array<char, 256> buffer{};
         std::string result;
         std::shared_ptr<FILE> pipe(popen(cmd.c_str(), "r"), pclose);
@@ -50,4 +50,9 @@ void ContextAgent::OnContextChanged(const std::string &processName, const std::s
     Focus::Event event = FocusSerializer::CreateEventFromContext("ContextChanged", context);
 
     _eventEmitter->Emit("NewEvent", event);
+}
+
+ContextAgent::~ContextAgent() {
+    _isRunning = false;
+    _eventListener->join();
 }

--- a/MacOs/Sources/ContextAgent.cpp
+++ b/MacOs/Sources/ContextAgent.cpp
@@ -55,7 +55,6 @@ void ContextAgent::OnContextChanged(const std::string &processName, const std::s
 ContextAgent::~ContextAgent() {
     _isRunning = false;
     _eventListener->join();
-    spdlog::get("logger")->info("ContextAgent is shutting down");
 }
 
 ContextAgent::ContextAgent() {

--- a/MacOs/Sources/ContextAgent.cpp
+++ b/MacOs/Sources/ContextAgent.cpp
@@ -11,7 +11,8 @@
 #include <spdlog/spdlog.h>
 #include <array>
 
-void ContextAgent::Run() {
+void ContextAgent::Run(std::atomic<bool> &sigReceived) {
+    _sigReceived = sigReceived.load();
     _eventListener = std::make_unique<std::thread>(std::bind(&ContextAgent::EventListener, this));
 }
 
@@ -19,7 +20,7 @@ void ContextAgent::EventListener() {
     std::string cmd = "osascript ./printAppTitle.scpt";
     std::string oldProcessName;
     std::string oldWindowsTitle;
-    while (_isRunning) {
+    while (_isRunning && !_sigReceived) {
         std::array<char, 256> buffer{};
         std::string result;
         std::shared_ptr<FILE> pipe(popen(cmd.c_str(), "r"), pclose);
@@ -38,7 +39,7 @@ void ContextAgent::EventListener() {
                 OnContextChanged(processName, windowsTitle);
             }
         }
-        sleep(2);
+        std::this_thread::sleep_for(std::chrono::seconds(2));
     }
 }
 

--- a/MacOs/Sources/ContextAgent.cpp
+++ b/MacOs/Sources/ContextAgent.cpp
@@ -55,4 +55,9 @@ void ContextAgent::OnContextChanged(const std::string &processName, const std::s
 ContextAgent::~ContextAgent() {
     _isRunning = false;
     _eventListener->join();
+    spdlog::get("logger")->info("ContextAgent is shutting down");
+}
+
+ContextAgent::ContextAgent() {
+    _isRunning = true;
 }

--- a/MacOs/main.cpp
+++ b/MacOs/main.cpp
@@ -4,6 +4,7 @@
 
 #include <spdlog/spdlog.h>
 #include "FocusDaemon.hpp"
+#include <condition_variable>
 
 std::mutex mtx;
 std::condition_variable cv;

--- a/MacOs/main.cpp
+++ b/MacOs/main.cpp
@@ -5,17 +5,25 @@
 #include <spdlog/spdlog.h>
 #include "FocusDaemon.hpp"
 
+std::mutex mtx;
+std::condition_variable cv;
+std::atomic<bool> sigReceived;
+
 void exitProgram(int sig) {
+    sigReceived = true;
     spdlog::set_pattern("\t*****  %v  *****");
     spdlog::get("logger")->info("End of program");
     spdlog::get("logger")->flush();
     spdlog::drop_all();
+    std::unique_lock<std::mutex> lck(mtx);
+    cv.notify_all();
 }
 
 int main(const int ac, const char **av) {
     signal(SIGABRT, &exitProgram);
     signal(SIGTERM, &exitProgram);
     signal(SIGINT, &exitProgram);
+    sigReceived = false;
 
     auto console = spdlog::stdout_color_mt("console");
     std::vector<spdlog::sink_ptr> sinks;
@@ -29,8 +37,10 @@ int main(const int ac, const char **av) {
     spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [thread %t] [%l]\t\t: %v");
 
     FocusDaemon daemon;
-    daemon.Run("daemon.config");
+    daemon.Run("daemon.config", sigReceived);
 
-    exitProgram(0);
+    std::unique_lock<std::mutex> lck(mtx);
+    cv.wait(lck);
+
     return (0);
 }

--- a/Shared/Headers/FocusDaemon.hpp
+++ b/Shared/Headers/FocusDaemon.hpp
@@ -17,13 +17,12 @@ class FocusDaemon {
 private:
     std::shared_ptr<FocusAuthenticator> Authenticator = std::make_shared<FocusAuthenticator>();
     std::shared_ptr<FocusConfiguration> _config;
-
     std::unique_ptr<FocusKeyLogger> KeyLogger = std::make_unique<FocusKeyLogger>();
     std::unique_ptr<FocusNetworkManager> NetworkManager = std::make_unique<FocusNetworkManager>();
     std::unique_ptr<FocusEventManager> EventManager = std::make_unique<FocusEventManager>();
     std::string _device_id = "";
 public:
-    void Run(const std::string &configFileName);
+    void Run(const std::string &configFileName, std::atomic<bool> &sigReceived);
 };
 
 #endif //FOCUS_CLIENT_FOCUSDAEMON_HPP

--- a/Shared/Headers/FocusDaemon.hpp
+++ b/Shared/Headers/FocusDaemon.hpp
@@ -16,10 +16,11 @@
 class FocusDaemon {
 private:
     std::shared_ptr<FocusAuthenticator> Authenticator = std::make_shared<FocusAuthenticator>();
+    std::shared_ptr<FocusConfiguration> _config;
+
     std::unique_ptr<FocusKeyLogger> KeyLogger = std::make_unique<FocusKeyLogger>();
     std::unique_ptr<FocusNetworkManager> NetworkManager = std::make_unique<FocusNetworkManager>();
     std::unique_ptr<FocusEventManager> EventManager = std::make_unique<FocusEventManager>();
-    std::shared_ptr<FocusConfiguration> _config;
     std::string _device_id = "";
 public:
     void Run(const std::string &configFileName);

--- a/Shared/Headers/FocusEventEmitter.hpp
+++ b/Shared/Headers/FocusEventEmitter.hpp
@@ -17,6 +17,8 @@ private:
 public:
     FocusEventEmitter();
 
+    virtual ~FocusEventEmitter();
+
     void Emit(const std::string &dest, const Focus::Event &payload) const;
 
     void EmitEnvelope(const std::string &dest, const Focus::Envelope &envelope) const;

--- a/Shared/Headers/FocusEventEmitter.hpp
+++ b/Shared/Headers/FocusEventEmitter.hpp
@@ -12,7 +12,7 @@
 
 class FocusEventEmitter {
 private:
-    std::shared_ptr<zmq::socket_t> _socketPUB = std::make_shared<zmq::socket_t>(*FocusSocket::Context, ZMQ_PUB);
+    std::unique_ptr<zmq::socket_t> _socketPUB = std::make_unique<zmq::socket_t>(*FocusSocket::Context, ZMQ_PUB);
 
 public:
     FocusEventEmitter();

--- a/Shared/Headers/FocusEventListener.hpp
+++ b/Shared/Headers/FocusEventListener.hpp
@@ -17,7 +17,7 @@ class FocusEventListener {
 private:
     std::function<void(TPayload &payload)> _onMessage;
     std::unique_ptr<std::thread> _eventListenerThread;
-    std::shared_ptr<zmq::socket_t> _socketSUB = std::make_shared<zmq::socket_t>(*FocusSocket::Context, ZMQ_SUB);
+    std::unique_ptr<zmq::socket_t> _socketSUB = std::make_unique<zmq::socket_t>(*FocusSocket::Context, ZMQ_SUB);
 
     static void RunReceive(zmq::socket_t *socketSUB, const std::function<void(TPayload &)> onMessage) {
         while (true) {

--- a/Shared/Headers/FocusEventListener.hpp
+++ b/Shared/Headers/FocusEventListener.hpp
@@ -27,6 +27,8 @@ private:
         while (_isRunning) {
             zmq::message_t msg;
             if (socketSUB->recv(&msg)) {
+                if (!socketSUB->recv(&msg))
+                    continue;
                 std::string payload = std::string(static_cast<char *>(msg.data()), msg.size());
                 Focus::Event event;
                 if (!event.ParseFromString(payload))
@@ -40,6 +42,8 @@ private:
         while (_isRunning) {
             zmq::message_t msg;
             if (socketSUB->recv(&msg)) {
+                if (!socketSUB->recv(&msg))
+                    continue;
                 std::string payload = std::string(static_cast<char *>(msg.data()), msg.size());
                 Focus::Envelope envelope;
                 if (!envelope.ParseFromString(payload))
@@ -53,6 +57,8 @@ private:
         while (_isRunning) {
             zmq::message_t msg;
             if (socketSUB->recv(&msg)) {
+                if (!socketSUB->recv(&msg))
+                    continue;
                 std::string payload = std::string(static_cast<char *>(msg.data()), msg.size());
                 onMessage(payload);
             }

--- a/Shared/Headers/FocusEventListener.hpp
+++ b/Shared/Headers/FocusEventListener.hpp
@@ -11,71 +11,83 @@
 #include <FocusSocket.hpp>
 #include <FocusEvent.pb.h>
 #include <FocusEnvelope.pb.h>
+#include <atomic>
+#include <iostream>
 
 template<class TPayload>
 class FocusEventListener {
 private:
+    int _socketTimeout = 1000; //milliseconds
     std::function<void(TPayload &payload)> _onMessage;
     std::unique_ptr<std::thread> _eventListenerThread;
     std::unique_ptr<zmq::socket_t> _socketSUB = std::make_unique<zmq::socket_t>(*FocusSocket::Context, ZMQ_SUB);
+    std::atomic<bool> _isRunning;
 
-    static void RunReceive(zmq::socket_t *socketSUB, const std::function<void(TPayload &)> onMessage) {
-        while (true) {
+    void RunReceive(zmq::socket_t *socketSUB, const std::function<void(TPayload &)> onMessage) {
+        while (_isRunning) {
             zmq::message_t msg;
-            socketSUB->recv(&msg);
-            socketSUB->recv(&msg);
-            std::string payload = std::string(static_cast<char*>(msg.data()), msg.size());
-            Focus::Event event;
-            if (!event.ParseFromString(payload))
-                continue;
-            onMessage(event);
+            if (socketSUB->recv(&msg)) {
+                std::string payload = std::string(static_cast<char *>(msg.data()), msg.size());
+                Focus::Event event;
+                if (!event.ParseFromString(payload))
+                    continue;
+                onMessage(event);
+            }
         }
     }
 
-    static void RunReceiveEnvelope(zmq::socket_t *socketSUB, const std::function<void(TPayload &)> onMessage) {
-        while (true) {
+    void RunReceiveEnvelope(zmq::socket_t *socketSUB, const std::function<void(TPayload &)> onMessage) {
+        while (_isRunning) {
             zmq::message_t msg;
-            socketSUB->recv(&msg);
-            socketSUB->recv(&msg);
-            std::string payload = std::string(static_cast<char*>(msg.data()), msg.size());
-            Focus::Envelope envelope;
-            if (!envelope.ParseFromString(payload))
-                continue;
-            onMessage(envelope);
+            if (socketSUB->recv(&msg)) {
+                std::string payload = std::string(static_cast<char *>(msg.data()), msg.size());
+                Focus::Envelope envelope;
+                if (!envelope.ParseFromString(payload))
+                    continue;
+                onMessage(envelope);
+            }
         }
     }
 
-    static void RunReceiveMessage(zmq::socket_t *socketSUB, const std::function<void(TPayload &)> onMessage) {
-        while (true) {
+    void RunReceiveMessage(zmq::socket_t *socketSUB, const std::function<void(TPayload &)> onMessage) {
+        while (_isRunning) {
             zmq::message_t msg;
-            socketSUB->recv(&msg);
-            socketSUB->recv(&msg);
-            std::string payload = std::string(static_cast<char*>(msg.data()), msg.size());
-            onMessage(payload);
+            if (socketSUB->recv(&msg)) {
+                std::string payload = std::string(static_cast<char *>(msg.data()), msg.size());
+                onMessage(payload);
+            }
         }
     }
 
 public:
     FocusEventListener() {
         _socketSUB->connect("inproc:///tmp/EventEmitter");
+        _socketSUB->setsockopt(ZMQ_RCVTIMEO, &_socketTimeout, sizeof(_socketTimeout));
+        _isRunning = true;
+    }
+
+    virtual ~FocusEventListener() {
+        _isRunning = false;
+        _eventListenerThread->join();
+        _socketSUB->close();
     }
 
     void Register(const std::string &payloadType, const std::function<void(TPayload &)> onMessage) {
         _socketSUB->setsockopt(ZMQ_SUBSCRIBE, payloadType.c_str(), payloadType.size());
         _onMessage = onMessage;
-        _eventListenerThread = std::make_unique<std::thread>(RunReceive, _socketSUB.get(), _onMessage);
+        _eventListenerThread = std::make_unique<std::thread>(&FocusEventListener::RunReceive, this, _socketSUB.get(), _onMessage);
     }
 
     void RegisterEnvelope(const std::string &payloadType, const std::function<void(TPayload &)> onMessage) {
         _socketSUB->setsockopt(ZMQ_SUBSCRIBE, payloadType.c_str(), payloadType.size());
         _onMessage = onMessage;
-        _eventListenerThread = std::make_unique<std::thread>(RunReceiveEnvelope, _socketSUB.get(), _onMessage);
+        _eventListenerThread = std::make_unique<std::thread>(&FocusEventListener::RunReceiveEnvelope, this, _socketSUB.get(), _onMessage);
     }
 
     void RegisterMessage(const std::string &payloadType, const std::function<void(TPayload &)> onMessage) {
         _socketSUB->setsockopt(ZMQ_SUBSCRIBE, payloadType.c_str(), payloadType.size());
         _onMessage = onMessage;
-        _eventListenerThread = std::make_unique<std::thread>(RunReceiveMessage, _socketSUB.get(), _onMessage);
+        _eventListenerThread = std::make_unique<std::thread>(&FocusEventListener::RunReceiveMessage, this, _socketSUB.get(), _onMessage);
     }
 };
 

--- a/Shared/Headers/FocusEventManager.hpp
+++ b/Shared/Headers/FocusEventManager.hpp
@@ -11,12 +11,18 @@
 class FocusEventManager {
 private:
     std::shared_ptr<zmq::socket_t> _socketPUB;
-	std::shared_ptr<zmq::socket_t> _socketSUB;
-	std::unique_ptr<std::thread> _eventManagerThread;
-	void RunReceive() const;
+    std::shared_ptr<zmq::socket_t> _socketSUB;
+    std::atomic<bool> _isRunning = true;
+    std::unique_ptr<std::thread> _eventManagerThread;
+
+    void RunReceive() const;
+
 public:
-	FocusEventManager();
-	void Run() ;
+    FocusEventManager();
+
+    ~FocusEventManager();
+
+    void Run();
 };
 
 #endif //FOCUS_CLIENT_FOCUSEVENTMANAGER_HPP

--- a/Shared/Headers/FocusEventManager.hpp
+++ b/Shared/Headers/FocusEventManager.hpp
@@ -14,6 +14,7 @@ private:
     std::unique_ptr<zmq::socket_t> _socketPUB;
     std::unique_ptr<zmq::socket_t> _socketSUB;
     std::atomic<bool> _isRunning;
+    std::atomic<bool> _sigReceived;
     std::unique_ptr<std::thread> _eventManagerThread;
 
     void RunReceive() const;
@@ -23,7 +24,7 @@ public:
 
     virtual ~FocusEventManager();
 
-    void Run();
+    void Run(std::atomic<bool> &sigReceived);
 };
 
 #endif //FOCUS_CLIENT_FOCUSEVENTMANAGER_HPP

--- a/Shared/Headers/FocusEventManager.hpp
+++ b/Shared/Headers/FocusEventManager.hpp
@@ -7,6 +7,7 @@
 
 #include <thread>
 #include <FocusSocket.hpp>
+#include <atomic>
 
 class FocusEventManager {
 private:

--- a/Shared/Headers/FocusEventManager.hpp
+++ b/Shared/Headers/FocusEventManager.hpp
@@ -10,9 +10,9 @@
 
 class FocusEventManager {
 private:
-    std::shared_ptr<zmq::socket_t> _socketPUB;
-    std::shared_ptr<zmq::socket_t> _socketSUB;
-    std::atomic<bool> _isRunning = true;
+    std::unique_ptr<zmq::socket_t> _socketPUB;
+    std::unique_ptr<zmq::socket_t> _socketSUB;
+    std::atomic<bool> _isRunning;
     std::unique_ptr<std::thread> _eventManagerThread;
 
     void RunReceive() const;
@@ -20,7 +20,7 @@ private:
 public:
     FocusEventManager();
 
-    ~FocusEventManager();
+    virtual ~FocusEventManager();
 
     void Run();
 };

--- a/Shared/Headers/FocusKeyLogger.hpp
+++ b/Shared/Headers/FocusKeyLogger.hpp
@@ -17,14 +17,13 @@
 
 class FocusKeyLogger {
 private:
-    std::unique_ptr<std::thread> _keyLoggerThread;
-    std::atomic<bool> _isRunning = true;
+    std::shared_ptr<FocusAuthenticator> _authenticator;
+
     std::unique_ptr<IContextAgent> _contextAgent = std::unique_ptr<IContextAgent>(std::make_unique<ContextAgent>());
     std::unique_ptr<IAfkListener> _afkListener = std::unique_ptr<IAfkListener>(std::make_unique<AfkListener>());
     std::unique_ptr<FocusEventListener<Focus::Event>> _eventListener = std::make_unique<FocusEventListener<Focus::Event>>();
     std::unique_ptr<FocusEventListener<const std::string &>> _messageListener = std::make_unique<FocusEventListener<const std::string &>>();
     std::unique_ptr<FocusEventEmitter> _eventEmitter = std::make_unique<FocusEventEmitter>();
-    std::shared_ptr<FocusAuthenticator> _authenticator;
     std::vector<Focus::Event> _events;
 
     void AddEvent(const Focus::Event &event);

--- a/Shared/Headers/FocusKeyLogger.hpp
+++ b/Shared/Headers/FocusKeyLogger.hpp
@@ -18,7 +18,6 @@
 class FocusKeyLogger {
 private:
     std::shared_ptr<FocusAuthenticator> _authenticator;
-
     std::unique_ptr<IContextAgent> _contextAgent = std::unique_ptr<IContextAgent>(std::make_unique<ContextAgent>());
     std::unique_ptr<IAfkListener> _afkListener = std::unique_ptr<IAfkListener>(std::make_unique<AfkListener>());
     std::unique_ptr<FocusEventListener<Focus::Event>> _eventListener = std::make_unique<FocusEventListener<Focus::Event>>();
@@ -28,10 +27,8 @@ private:
 
     void AddEvent(const Focus::Event &event);
 
-    void RunKeyLogger();
-
 public:
-    void Run(std::shared_ptr<FocusAuthenticator> &authenticator, std::shared_ptr<FocusConfiguration> &config);
+    void Run(std::shared_ptr<FocusAuthenticator> &authenticator, std::shared_ptr<FocusConfiguration> &config, std::atomic<bool> &sigReceived);
 };
 
 #endif //FOCUS_CLIENT_FOCUSKEYLOGGER_HPP

--- a/Shared/Headers/FocusKeyLogger.hpp
+++ b/Shared/Headers/FocusKeyLogger.hpp
@@ -18,6 +18,7 @@
 class FocusKeyLogger {
 private:
     std::unique_ptr<std::thread> _keyLoggerThread;
+    std::atomic<bool> _isRunning = true;
     std::unique_ptr<IContextAgent> _contextAgent = std::unique_ptr<IContextAgent>(std::make_unique<ContextAgent>());
     std::unique_ptr<IAfkListener> _afkListener = std::unique_ptr<IAfkListener>(std::make_unique<AfkListener>());
     std::unique_ptr<FocusEventListener<Focus::Event>> _eventListener = std::make_unique<FocusEventListener<Focus::Event>>();

--- a/Shared/Headers/FocusNetworkManager.hpp
+++ b/Shared/Headers/FocusNetworkManager.hpp
@@ -16,7 +16,7 @@ class FocusNetworkManager {
 private:
     std::shared_ptr<FocusSocket> _socket;
     std::unique_ptr<std::thread> _networkManagerThread;
-    std::atomic<bool> _isRunning = true;
+    std::atomic<bool> _isRunning;
     std::unique_ptr<FocusEventListener<Focus::Envelope>> _eventListener = std::make_unique<FocusEventListener<Focus::Envelope>>();
     std::unique_ptr<FocusEventEmitter> _eventEmitter = std::make_unique<FocusEventEmitter>();
     std::string _device_id;
@@ -25,7 +25,7 @@ private:
 public:
     FocusNetworkManager();
 
-    ~FocusNetworkManager();
+    virtual ~FocusNetworkManager();
 
     void Run(const std::string &device_id, std::shared_ptr<FocusConfiguration> &config);
 };

--- a/Shared/Headers/FocusNetworkManager.hpp
+++ b/Shared/Headers/FocusNetworkManager.hpp
@@ -18,6 +18,7 @@ private:
     std::shared_ptr<FocusSocket> _socket;
     std::unique_ptr<std::thread> _networkManagerThread;
     std::atomic<bool> _isRunning;
+    std::atomic<bool> _sigReceived;
     std::unique_ptr<FocusEventListener<Focus::Envelope>> _eventListener = std::make_unique<FocusEventListener<Focus::Envelope>>();
     std::unique_ptr<FocusEventEmitter> _eventEmitter = std::make_unique<FocusEventEmitter>();
     std::string _device_id;
@@ -28,7 +29,7 @@ public:
 
     virtual ~FocusNetworkManager();
 
-    void Run(const std::string &device_id, std::shared_ptr<FocusConfiguration> &config);
+    void Run(const std::string &device_id, std::shared_ptr<FocusConfiguration> &config, std::atomic<bool> &sigReceived);
 };
 
 #endif //FOCUS_CLIENT_FOCUSNETWORKMANAGER_HPP

--- a/Shared/Headers/FocusNetworkManager.hpp
+++ b/Shared/Headers/FocusNetworkManager.hpp
@@ -16,6 +16,7 @@ class FocusNetworkManager {
 private:
     std::shared_ptr<FocusSocket> _socket;
     std::unique_ptr<std::thread> _networkManagerThread;
+    std::atomic<bool> _isRunning = true;
     std::unique_ptr<FocusEventListener<Focus::Envelope>> _eventListener = std::make_unique<FocusEventListener<Focus::Envelope>>();
     std::unique_ptr<FocusEventEmitter> _eventEmitter = std::make_unique<FocusEventEmitter>();
     std::string _device_id;

--- a/Shared/Headers/FocusNetworkManager.hpp
+++ b/Shared/Headers/FocusNetworkManager.hpp
@@ -11,6 +11,7 @@
 #include <FocusEnvelope.pb.h>
 #include "FocusEventEmitter.hpp"
 #include "FocusConfiguration.hpp"
+#include <atomic>
 
 class FocusNetworkManager {
 private:

--- a/Shared/Headers/FocusSecureSocket.hpp
+++ b/Shared/Headers/FocusSecureSocket.hpp
@@ -29,9 +29,9 @@ template <>
 class FocusSecureSocket<Client> : public FocusSocket {
 public:
     FocusSecureSocket(const std::string &serverKey, const std::string &publicKey, const std::string &clientSecretKey) : FocusSocket() {
-        _socket->setsockopt(ZMQ_CURVE_SERVERKEY, strdup(serverKey.c_str()), serverKey.size());
-        _socket->setsockopt(ZMQ_CURVE_PUBLICKEY, strdup(publicKey.c_str()), publicKey.size());
-        _socket->setsockopt(ZMQ_CURVE_SECRETKEY, strdup(clientSecretKey.c_str()), clientSecretKey.size());
+        _socket->setsockopt(ZMQ_CURVE_SERVERKEY, serverKey.c_str(), serverKey.size());
+        _socket->setsockopt(ZMQ_CURVE_PUBLICKEY, publicKey.c_str(), publicKey.size());
+        _socket->setsockopt(ZMQ_CURVE_SECRETKEY, clientSecretKey.c_str(), clientSecretKey.size());
     }
 };
 

--- a/Shared/Interfaces/IAfkListener.hpp
+++ b/Shared/Interfaces/IAfkListener.hpp
@@ -5,12 +5,12 @@
 #ifndef DAEMON_IAFKLISTENER_HPP
 #define DAEMON_IAFKLISTENER_HPP
 
-
+#include <atomic>
 #include <chrono>
 
 class IAfkListener {
 public:
-    virtual void Run(int triggerAfkInSecond) = 0;
+    virtual void Run(int triggerAfkInSecond, std::atomic<bool> &sigReceived) = 0;
 
     virtual ~IAfkListener() {}
 

--- a/Shared/Interfaces/IAfkListener.hpp
+++ b/Shared/Interfaces/IAfkListener.hpp
@@ -12,6 +12,8 @@ class IAfkListener {
 public:
     virtual void Run(int triggerAfkInSecond) = 0;
 
+    virtual ~IAfkListener() {}
+
 private:
     virtual void EventListener() = 0;
 

--- a/Shared/Interfaces/IContextAgent.hpp
+++ b/Shared/Interfaces/IContextAgent.hpp
@@ -13,6 +13,8 @@ public:
 
 	virtual void OnContextChanged(const std::string &processName, const std::string &windowTitle) const = 0;
 
+	virtual ~IContextAgent() {}
+
 private:
     virtual void EventListener() = 0;
 };

--- a/Shared/Interfaces/IContextAgent.hpp
+++ b/Shared/Interfaces/IContextAgent.hpp
@@ -5,11 +5,12 @@
 #ifndef FOCUS_CLIENT_IWINDOWSCONTEXTAGENT_HPP
 #define FOCUS_CLIENT_IWINDOWSCONTEXTAGENT_HPP
 
+#include <atomic>
 #include <string>
 
 class IContextAgent {
 public:
-    virtual void Run() = 0;
+    virtual void Run(std::atomic<bool> &sigReceived) = 0;
 
 	virtual void OnContextChanged(const std::string &processName, const std::string &windowTitle) const = 0;
 

--- a/Shared/Sources/FocusDaemon.cpp
+++ b/Shared/Sources/FocusDaemon.cpp
@@ -24,7 +24,6 @@ void FocusDaemon::Run(const std::string &configFileName) {
     if (!_device_id.empty()) {
         spdlog::get("logger")->info("Device Id: {}", _device_id);
         NetworkManager->Run(_device_id, _config);
-        KeyLogger->Run(Authenticator, _config);
+        KeyLogger->Run(Authenticator, _config); // This will hold the current thread
     }
-    std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::hours((std::numeric_limits<int>::max)()));
 }

--- a/Shared/Sources/FocusDaemon.cpp
+++ b/Shared/Sources/FocusDaemon.cpp
@@ -24,6 +24,7 @@ void FocusDaemon::Run(const std::string &configFileName) {
     if (!_device_id.empty()) {
         spdlog::get("logger")->info("Device Id: {}", _device_id);
         NetworkManager->Run(_device_id, _config);
-        KeyLogger->Run(Authenticator, _config); // This will hold the current thread
+        KeyLogger->Run(Authenticator, _config);
     }
+    std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::seconds(5));
 }

--- a/Shared/Sources/FocusDaemon.cpp
+++ b/Shared/Sources/FocusDaemon.cpp
@@ -5,9 +5,9 @@
 #include <FocusDaemon.hpp>
 #include <spdlog/spdlog.h>
 
-void FocusDaemon::Run(const std::string &configFileName) {
+void FocusDaemon::Run(const std::string &configFileName, std::atomic<bool> &sigReceived) {
     spdlog::get("logger")->info("FocusDaemon is running");
-    EventManager->Run();
+    EventManager->Run(sigReceived);
     _config = std::make_shared<FocusConfiguration>(configFileName);
     auto usr = _config->getUser();
     Authenticator->Run(_config);
@@ -23,8 +23,7 @@ void FocusDaemon::Run(const std::string &configFileName) {
     }
     if (!_device_id.empty()) {
         spdlog::get("logger")->info("Device Id: {}", _device_id);
-        NetworkManager->Run(_device_id, _config);
-        KeyLogger->Run(Authenticator, _config);
+        NetworkManager->Run(_device_id, _config, sigReceived);
+        KeyLogger->Run(Authenticator, _config, sigReceived);
     }
-    std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::seconds(500));
 }

--- a/Shared/Sources/FocusDaemon.cpp
+++ b/Shared/Sources/FocusDaemon.cpp
@@ -26,5 +26,5 @@ void FocusDaemon::Run(const std::string &configFileName) {
         NetworkManager->Run(_device_id, _config);
         KeyLogger->Run(Authenticator, _config);
     }
-    std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::seconds(5));
+    std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::seconds(500));
 }

--- a/Shared/Sources/FocusEventEmitter.cpp
+++ b/Shared/Sources/FocusEventEmitter.cpp
@@ -30,3 +30,7 @@ void FocusEventEmitter::EmitMessage(const std::string &dest, const std::string &
     msg.addstr(message);
     msg.send(*_socketPUB);
 }
+
+FocusEventEmitter::~FocusEventEmitter() {
+    _socketPUB->close();
+}

--- a/Shared/Sources/FocusEventManager.cpp
+++ b/Shared/Sources/FocusEventManager.cpp
@@ -7,8 +7,9 @@
 #include <spdlog/spdlog.h>
 
 FocusEventManager::FocusEventManager() {
-    _socketPUB = std::make_shared<zmq::socket_t>(*FocusSocket::Context, ZMQ_PUB);
-    _socketSUB = std::make_shared<zmq::socket_t>(*FocusSocket::Context, ZMQ_SUB);
+    _isRunning = true;
+    _socketPUB = std::make_unique<zmq::socket_t>(*FocusSocket::Context, ZMQ_PUB);
+    _socketSUB = std::make_unique<zmq::socket_t>(*FocusSocket::Context, ZMQ_SUB);
 }
 
 void FocusEventManager::Run() {
@@ -39,4 +40,5 @@ void FocusEventManager::RunReceive() const {
 FocusEventManager::~FocusEventManager() {
     _isRunning = false;
     _eventManagerThread->join();
+    spdlog::get("logger")->info("FocusEventManager is shutting down");
 }

--- a/Shared/Sources/FocusEventManager.cpp
+++ b/Shared/Sources/FocusEventManager.cpp
@@ -4,7 +4,6 @@
 
 #include <FocusEventManager.hpp>
 #include <iostream>
-#include <spdlog/spdlog.h>
 
 FocusEventManager::FocusEventManager() {
     _isRunning = true;

--- a/Shared/Sources/FocusEventManager.cpp
+++ b/Shared/Sources/FocusEventManager.cpp
@@ -10,11 +10,11 @@ FocusEventManager::FocusEventManager() {
     _isRunning = true;
     _socketPUB = std::make_unique<zmq::socket_t>(*FocusSocket::Context, ZMQ_PUB);
     _socketSUB = std::make_unique<zmq::socket_t>(*FocusSocket::Context, ZMQ_SUB);
+    int _socketTimeout = 1000; //milliseconds
+    _socketSUB->setsockopt(ZMQ_RCVTIMEO, &_socketTimeout, sizeof(_socketTimeout));
 }
 
 void FocusEventManager::Run() {
-    spdlog::get("logger")->info("FocusEventManager is running");
-
     _socketPUB->bind("inproc:///tmp/EventEmitter");
     _socketSUB->bind("inproc:///tmp/EventListener");
     _socketSUB->setsockopt(ZMQ_SUBSCRIBE, "", 0);
@@ -26,11 +26,13 @@ void FocusEventManager::RunReceive() const {
     while (_isRunning) {
         zmq::multipart_t rep;
         zmq::message_t msg;
-        _socketSUB->recv(&msg);
+        if (!_socketSUB->recv(&msg))
+            continue;
         std::string ret = std::string(static_cast<char*>(msg.data()), msg.size());
         rep.addstr(ret);
         zmq::message_t msg2;
-        _socketSUB->recv(&msg2);
+        if (!_socketSUB->recv(&msg2))
+            continue;
         ret = std::string(static_cast<char*>(msg2.data()), msg2.size());
         rep.addstr(ret);
         rep.send(*_socketPUB, 0);
@@ -40,5 +42,6 @@ void FocusEventManager::RunReceive() const {
 FocusEventManager::~FocusEventManager() {
     _isRunning = false;
     _eventManagerThread->join();
-    spdlog::get("logger")->info("FocusEventManager is shutting down");
+    _socketSUB->close();
+    _socketPUB->close();
 }

--- a/Shared/Sources/FocusEventManager.cpp
+++ b/Shared/Sources/FocusEventManager.cpp
@@ -22,7 +22,7 @@ void FocusEventManager::Run() {
 }
 
 void FocusEventManager::RunReceive() const {
-    while (true) {
+    while (_isRunning) {
         zmq::multipart_t rep;
         zmq::message_t msg;
         _socketSUB->recv(&msg);
@@ -34,4 +34,9 @@ void FocusEventManager::RunReceive() const {
         rep.addstr(ret);
         rep.send(*_socketPUB, 0);
     }
+}
+
+FocusEventManager::~FocusEventManager() {
+    _isRunning = false;
+    _eventManagerThread->join();
 }

--- a/Shared/Sources/FocusEventManager.cpp
+++ b/Shared/Sources/FocusEventManager.cpp
@@ -24,17 +24,9 @@ void FocusEventManager::Run(std::atomic<bool> &sigReceived) {
 void FocusEventManager::RunReceive() const {
     while (_isRunning && !_sigReceived) {
         zmq::multipart_t rep;
-        zmq::message_t msg;
-        if (!_socketSUB->recv(&msg))
-            continue;
-        std::string ret = std::string(static_cast<char*>(msg.data()), msg.size());
-        rep.addstr(ret);
-        zmq::message_t msg2;
-        if (!_socketSUB->recv(&msg2))
-            continue;
-        ret = std::string(static_cast<char*>(msg2.data()), msg2.size());
-        rep.addstr(ret);
-        rep.send(*_socketPUB, 0);
+        if (rep.recv(*_socketSUB)) {
+            rep.send(*_socketPUB);
+        }
     }
 }
 

--- a/Shared/Sources/FocusKeyLogger.cpp
+++ b/Shared/Sources/FocusKeyLogger.cpp
@@ -8,7 +8,6 @@
 #include "FocusSerializer.hpp"
 
 void FocusKeyLogger::Run(std::shared_ptr<FocusAuthenticator> &authenticator, std::shared_ptr<FocusConfiguration> &config) {
-    spdlog::get("logger")->info("FocusKeyLogger is running");
     _authenticator = authenticator;
 
     _eventListener->Register("NewEvent", [this](Focus::Event &newContext) {
@@ -23,8 +22,6 @@ void FocusKeyLogger::Run(std::shared_ptr<FocusAuthenticator> &authenticator, std
 
     _contextAgent->Run();
     _afkListener->Run(std::stoi(config->getTriggerAfk()));
-
-    std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::hours((std::numeric_limits<int>::max)()));
 }
 
 void FocusKeyLogger::AddEvent(const Focus::Event &ev) {

--- a/Shared/Sources/FocusKeyLogger.cpp
+++ b/Shared/Sources/FocusKeyLogger.cpp
@@ -23,6 +23,8 @@ void FocusKeyLogger::Run(std::shared_ptr<FocusAuthenticator> &authenticator, std
 
     _contextAgent->Run();
     _afkListener->Run(std::stoi(config->getTriggerAfk()));
+
+    std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::hours((std::numeric_limits<int>::max)()));
 }
 
 void FocusKeyLogger::AddEvent(const Focus::Event &ev) {

--- a/Shared/Sources/FocusKeyLogger.cpp
+++ b/Shared/Sources/FocusKeyLogger.cpp
@@ -7,7 +7,7 @@
 #include <spdlog/spdlog.h>
 #include "FocusSerializer.hpp"
 
-void FocusKeyLogger::Run(std::shared_ptr<FocusAuthenticator> &authenticator, std::shared_ptr<FocusConfiguration> &config) {
+void FocusKeyLogger::Run(std::shared_ptr<FocusAuthenticator> &authenticator, std::shared_ptr<FocusConfiguration> &config, std::atomic<bool> &sigReceived) {
     _authenticator = authenticator;
 
     _eventListener->Register("NewEvent", [this](Focus::Event &newContext) {
@@ -20,8 +20,8 @@ void FocusKeyLogger::Run(std::shared_ptr<FocusAuthenticator> &authenticator, std
         _events.clear();
     });
 
-    _contextAgent->Run();
-    _afkListener->Run(std::stoi(config->getTriggerAfk()));
+    _contextAgent->Run(sigReceived);
+    _afkListener->Run(std::stoi(config->getTriggerAfk()), sigReceived);
 }
 
 void FocusKeyLogger::AddEvent(const Focus::Event &ev) {

--- a/Shared/Sources/FocusNetworkManager.cpp
+++ b/Shared/Sources/FocusNetworkManager.cpp
@@ -10,6 +10,7 @@
 #include <spdlog/spdlog.h>
 
 FocusNetworkManager::FocusNetworkManager() {
+    _isRunning = true;
     _socket = std::static_pointer_cast<FocusSocket>(std::make_shared<FocusSecureSocket<Client>>("rq:rM>}U?@Lns47E1%kR.o@n%FcmmsL/@{H8]yf7", "Yne@$w-vo<fVvi]a<NY6T1ed:M$fCG*[IaLV{hID", "D:)Q[IlAW!ahhC2ac:9*A}h:p?([4%wOTJ%JR%cs"));
 }
 
@@ -17,6 +18,7 @@ FocusNetworkManager::~FocusNetworkManager() {
     _socket->Disconnect();
     _isRunning = false;
     _networkManagerThread->join();
+    spdlog::get("logger")->info("FocusNetworkManager is shutting down");
 }
 
 void FocusNetworkManager::Run(const std::string &device_id, std::shared_ptr<FocusConfiguration> &config) {

--- a/Shared/Sources/FocusNetworkManager.cpp
+++ b/Shared/Sources/FocusNetworkManager.cpp
@@ -20,7 +20,7 @@ FocusNetworkManager::~FocusNetworkManager() {
     _socket->Disconnect();
 }
 
-void FocusNetworkManager::Run(const std::string &device_id, std::shared_ptr<FocusConfiguration> &config) {
+void FocusNetworkManager::Run(const std::string &device_id, std::shared_ptr<FocusConfiguration> &config, std::atomic<bool> &sigReceived) {
     auto srv = config->getServer(serverType::BACKEND);
     std::string urlStr = "tcp://";
     urlStr += srv._ip;
@@ -28,6 +28,7 @@ void FocusNetworkManager::Run(const std::string &device_id, std::shared_ptr<Focu
     urlStr += std::to_string(srv._port);
 
     _device_id = device_id;
+    _sigReceived = sigReceived.load();
 
     _socket->Connect(urlStr);
 

--- a/Shared/Sources/FocusNetworkManager.cpp
+++ b/Shared/Sources/FocusNetworkManager.cpp
@@ -15,15 +15,12 @@ FocusNetworkManager::FocusNetworkManager() {
 }
 
 FocusNetworkManager::~FocusNetworkManager() {
-    _socket->Disconnect();
     _isRunning = false;
     _networkManagerThread->join();
-    spdlog::get("logger")->info("FocusNetworkManager is shutting down");
+    _socket->Disconnect();
 }
 
 void FocusNetworkManager::Run(const std::string &device_id, std::shared_ptr<FocusConfiguration> &config) {
-    spdlog::get("logger")->info("FocusNetworkManager is running");
-
     auto srv = config->getServer(serverType::BACKEND);
     std::string urlStr = "tcp://";
     urlStr += srv._ip;

--- a/Shared/Sources/FocusNetworkManager.cpp
+++ b/Shared/Sources/FocusNetworkManager.cpp
@@ -15,6 +15,8 @@ FocusNetworkManager::FocusNetworkManager() {
 
 FocusNetworkManager::~FocusNetworkManager() {
     _socket->Disconnect();
+    _isRunning = false;
+    _networkManagerThread->join();
 }
 
 void FocusNetworkManager::Run(const std::string &device_id, std::shared_ptr<FocusConfiguration> &config) {

--- a/Shared/Sources/FocusSocket.cpp
+++ b/Shared/Sources/FocusSocket.cpp
@@ -3,7 +3,6 @@
 //
 
 #include <FocusSocket.hpp>
-#include <spdlog/spdlog.h>
 
 zmq::context_t *FocusSocket::Context = new zmq::context_t();
 

--- a/Shared/Sources/FocusSocket.cpp
+++ b/Shared/Sources/FocusSocket.cpp
@@ -8,7 +8,7 @@
 zmq::context_t *FocusSocket::Context = new zmq::context_t();
 
 FocusSocket::FocusSocket() {
-    _socket = std::unique_ptr<zmq::socket_t>(new zmq::socket_t(*FocusSocket::Context, ZMQ_DEALER));
+    _socket = std::make_unique<zmq::socket_t>(*FocusSocket::Context, ZMQ_DEALER);
 }
 
 bool FocusSocket::Send(const std::string &deviceId, const std::string &payload) const {

--- a/Windows/Headers/AfkListener.hpp
+++ b/Windows/Headers/AfkListener.hpp
@@ -8,11 +8,13 @@
 #include <IAfkListener.hpp>
 #include <thread>
 #include <FocusEventEmitter.hpp>
+#include <atomic>
 
 class AfkListener : public IAfkListener {
 private:
     int _triggerAfkInSecond;
     std::unique_ptr<std::thread> _eventListener;
+	std::atomic<bool> _isRunning;
     std::unique_ptr<FocusEventEmitter> _eventEmitter = std::make_unique<FocusEventEmitter>();
 
     void EventListener() override final;
@@ -21,6 +23,10 @@ private:
 
 public:
     void Run(int triggerAfkInSecond) override final;
+
+	AfkListener();
+
+	virtual ~AfkListener();
 };
 
 

--- a/Windows/Headers/AfkListener.hpp
+++ b/Windows/Headers/AfkListener.hpp
@@ -14,7 +14,8 @@ class AfkListener : public IAfkListener {
 private:
     int _triggerAfkInSecond;
     std::unique_ptr<std::thread> _eventListener;
-	std::atomic<bool> _isRunning;
+    std::atomic<bool> _isRunning;
+    std::atomic<bool> _sigReceived;
     std::unique_ptr<FocusEventEmitter> _eventEmitter = std::make_unique<FocusEventEmitter>();
 
     void EventListener() override final;
@@ -22,11 +23,11 @@ private:
     void OnAfk(const std::chrono::milliseconds &timeSinceEpoch) const override final;
 
 public:
-    void Run(int triggerAfkInSecond) override final;
+    void Run(int triggerAfkInSecond, std::atomic<bool> &sigReceived) override final;
 
-	AfkListener();
+    AfkListener();
 
-	virtual ~AfkListener();
+    virtual ~AfkListener();
 };
 
 

--- a/Windows/Headers/ContextAgent.hpp
+++ b/Windows/Headers/ContextAgent.hpp
@@ -13,17 +13,16 @@
 #include <memory>
 #include "FocusEventEmitter.hpp"
 #include <thread>
+#include <atomic>
 
 class ContextAgent : public IContextAgent
 {
 private:
+	std::atomic<bool> _isRunning;
 	std::unique_ptr<std::thread> _eventListener;
 	std::unique_ptr<FocusEventEmitter> _eventEmitter = std::make_unique<FocusEventEmitter>();
-	HWINEVENTHOOK hEvent;
 
 	void EventListener() override final;
-
-	static VOID CALLBACK WinEventProcCallback(HWINEVENTHOOK hWinEventHook, DWORD dwEvent, HWND hwnd, LONG idObject, LONG idChild, DWORD dwEventThread, DWORD dwmsEventTime);
 
 public:
 	ContextAgent();

--- a/Windows/Headers/ContextAgent.hpp
+++ b/Windows/Headers/ContextAgent.hpp
@@ -15,23 +15,23 @@
 #include <thread>
 #include <atomic>
 
-class ContextAgent : public IContextAgent
-{
+class ContextAgent : public IContextAgent {
 private:
-	std::atomic<bool> _isRunning;
-	std::unique_ptr<std::thread> _eventListener;
-	std::unique_ptr<FocusEventEmitter> _eventEmitter = std::make_unique<FocusEventEmitter>();
+    std::atomic<bool> _isRunning;
+    std::atomic<bool> _sigReceived;
+    std::unique_ptr<std::thread> _eventListener;
+    std::unique_ptr<FocusEventEmitter> _eventEmitter = std::make_unique<FocusEventEmitter>();
 
-	void EventListener() override final;
+    void EventListener() override final;
 
 public:
-	ContextAgent();
+    ContextAgent();
 
-	~ContextAgent();
+    ~ContextAgent();
 
-	void Run() override final;
+    void Run(std::atomic<bool> &sigReceived) override final;
 
-	void OnContextChanged(const std::string& processName, const std::string& windowTitle) const override final;
+    void OnContextChanged(const std::string &processName, const std::string &windowTitle) const override final;
 };
 
 #endif //FOCUS_CLIENT_WINDOWSCONTEXTAGENT_HPP

--- a/Windows/Sources/AfkListener.cpp
+++ b/Windows/Sources/AfkListener.cpp
@@ -7,8 +7,9 @@
 #include <FocusAfkEventPayload.pb.h>
 #include <FocusSerializer.hpp>
 
-void AfkListener::Run(int triggerAfkInSecond) {
+void AfkListener::Run(int triggerAfkInSecond, std::atomic<bool> &sigReceived) {
     _triggerAfkInSecond = triggerAfkInSecond;
+    _sigReceived = sigReceived.load();
     _eventListener = std::make_unique<std::thread>(std::bind(&AfkListener::EventListener, this));
 }
 
@@ -18,7 +19,7 @@ void AfkListener::EventListener() {
     LASTINPUTINFO li;
     li.cbSize = sizeof(LASTINPUTINFO);
 
-    while (_isRunning) {
+    while (_isRunning  && !_sigReceived) {
         GetLastInputInfo(&li);
         DWORD te = ::GetTickCount();
         lastInputSince = (te - li.dwTime) / 1000;
@@ -33,7 +34,7 @@ void AfkListener::EventListener() {
                 afk = true;
             }
         }
-        Sleep(2000);
+        std::this_thread::sleep_for(std::chrono::seconds(2));
     }
 }
 

--- a/Windows/Sources/AfkListener.cpp
+++ b/Windows/Sources/AfkListener.cpp
@@ -18,7 +18,7 @@ void AfkListener::EventListener() {
     LASTINPUTINFO li;
     li.cbSize = sizeof(LASTINPUTINFO);
 
-    while (true) {
+    while (_isRunning) {
         GetLastInputInfo(&li);
         DWORD te = ::GetTickCount();
         lastInputSince = (te - li.dwTime) / 1000;
@@ -50,4 +50,13 @@ void AfkListener::OnAfk(const std::chrono::milliseconds &timeSinceEpoch) const {
     Focus::Event event = FocusSerializer::CreateEventFromContext("Afk", afk);
 
     _eventEmitter->Emit("NewEvent", event);
+}
+
+AfkListener::~AfkListener() {
+	_isRunning = false;
+	_eventListener->join();
+}
+
+AfkListener::AfkListener() {
+	_isRunning = true;
 }

--- a/Windows/Sources/ContextAgent.cpp
+++ b/Windows/Sources/ContextAgent.cpp
@@ -6,14 +6,14 @@
 #include "FocusSerializer.hpp"
 #include "FocusContextEventPayload.pb.h"
 
-IContextAgent *contextAgent;
 
 ContextAgent::ContextAgent() {
-	contextAgent = this; //This is mendatory for the hook to be able to communicate with our appContext.
+	_isRunning = true;
 }
 
 ContextAgent::~ContextAgent() {
-	UnhookWinEvent(hEvent);
+	_isRunning = false;
+	_eventListener->join();
 }
 
 void ContextAgent::Run() {
@@ -21,9 +21,27 @@ void ContextAgent::Run() {
 }
 
 void ContextAgent::EventListener() {
-	hEvent = SetWinEventHook(EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND, nullptr, WinEventProcCallback, 0, 0, WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS);
-	MSG msg;
-	GetMessage(&msg, nullptr, NULL, NULL); // Windows message loop keepalive. This will block the current thread.
+	std::string oldProcessName;
+	std::string oldWindowsTitle;
+	while (_isRunning) {
+		HWND hwnd = GetForegroundWindow();
+		DWORD processId = GetProcessId(hwnd);
+		char tmp[0xFF] = { 0 };
+		GetWindowThreadProcessId(hwnd, &processId);
+		HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, processId);
+		GetProcessImageFileName(hProcess, tmp, 0xFF);
+		std::string processName = std::string(tmp);
+		processName = processName.substr(processName.find_last_of("/\\") + 1);
+		GetWindowText(hwnd, tmp, 0xFF);
+		std::string windowsTitle = std::string(tmp);
+		if (oldProcessName != processName || oldWindowsTitle != windowsTitle) {
+			std::cout << "Process Name: " << processName << " Window Name: " << windowsTitle << std::endl;
+			oldProcessName = processName;
+			oldWindowsTitle = windowsTitle;
+			OnContextChanged(processName, windowsTitle);
+		}
+		Sleep(2000);
+	}
 }
 
 void ContextAgent::OnContextChanged(const std::string &processName, const std::string &windowTitle) const {
@@ -34,17 +52,4 @@ void ContextAgent::OnContextChanged(const std::string &processName, const std::s
 	Focus::Event event = FocusSerializer::CreateEventFromContext("ContextChanged", context);
 
 	_eventEmitter->Emit("NewEvent", event);
-}
-
-VOID CALLBACK ContextAgent::WinEventProcCallback(HWINEVENTHOOK hWinEventHook, DWORD dwEvent, HWND hwnd, LONG idObject, LONG idChild, DWORD dwEventThread, DWORD dwmsEventTime) {
-	DWORD processId;
-
-	char tmp[0xFF] = { 0 };
-	GetWindowThreadProcessId(hwnd, &processId);
-	HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, processId);
-	GetModuleBaseName(hProcess, nullptr, tmp, 0xFF);
-	std::string processName = std::string(tmp);
-	GetWindowText(hwnd, tmp, 0xFF);
-	std::string windowTitle = std::string(tmp);
-	contextAgent->OnContextChanged(processName, windowTitle);
 }


### PR DESCRIPTION
Now we have :
- [x] `std::atomic<bool>` in every ctor/dtor with control loop in every thread loop.
- [x] `std::condition_variable` to wait `SIGINT` from user to exit the program.

Fix :
- [x] 32/64 bits issue in windows with `GetModuleBaseName`
- [x] Removing callback on window when Context change, now we have a 2 seconds heartbeat.