### PR TITLE
Add virtual dtor on interfaces (clang 6)

### DIFF
--- a/Shared/Interfaces/IAfkListener.hpp
+++ b/Shared/Interfaces/IAfkListener.hpp
@@ -10,6 +10,8 @@
 
 class IAfkListener {
 public:
+    virtual ~IAfkListener() = default;
+
     virtual void Run(int triggerAfkInSecond) = 0;
 
 private:

--- a/Shared/Interfaces/IContextAgent.hpp
+++ b/Shared/Interfaces/IContextAgent.hpp
@@ -9,7 +9,9 @@
 
 class IContextAgent {
 public:
-    virtual void Run() = 0;
+	virtual ~IContextAgent() = default;
+
+	virtual void Run() = 0;
 
 	virtual void OnContextChanged(const std::string &processName, const std::string &windowTitle) const = 0;
 


### PR DESCRIPTION
Clang 6 warns me about implicit destructors on interfaces not being `virtual`. Fixes that.