### PR TITLE
Special folder resolve utility

### DIFF
--- a/Linux/main.cpp
+++ b/Linux/main.cpp
@@ -5,6 +5,7 @@
 #include <spdlog/spdlog.h>
 #include <condition_variable>
 #include "FocusDaemon.hpp"
+#include <FocusPlatformFolders.hpp>
 
 std::mutex mtx;
 std::condition_variable cv;
@@ -29,7 +30,7 @@ int main(const int ac, const char **av) {
     auto console = spdlog::stdout_color_mt("console");
     std::vector<spdlog::sink_ptr> sinks;
     sinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_mt>());
-    sinks.push_back(std::make_shared<spdlog::sinks::rotating_file_sink_mt>("logs/logs.txt", 1048576 * 5, 3));
+    sinks.push_back(std::make_shared<spdlog::sinks::rotating_file_sink_mt>(sago::getDataHome() + "/Focus/logs.txt", 1048576 * 5, 3));
     auto combined_logger = std::make_shared<spdlog::logger>("logger", begin(sinks), end(sinks));
     spdlog::register_logger(combined_logger);
 

--- a/MacOs/main.cpp
+++ b/MacOs/main.cpp
@@ -5,6 +5,7 @@
 #include <spdlog/spdlog.h>
 #include "FocusDaemon.hpp"
 #include <condition_variable>
+#include <FocusPlatformFolders.hpp>
 
 std::mutex mtx;
 std::condition_variable cv;
@@ -29,7 +30,7 @@ int main(const int ac, const char **av) {
     auto console = spdlog::stdout_color_mt("console");
     std::vector<spdlog::sink_ptr> sinks;
     sinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_mt>());
-    sinks.push_back(std::make_shared<spdlog::sinks::rotating_file_sink_mt>("logs/logs.txt", 1048576 * 5, 3));
+    sinks.push_back(std::make_shared<spdlog::sinks::rotating_file_sink_mt>(sago::getDataHome() + "/Focus/logs.txt", 1048576 * 5, 3));
     auto combined_logger = std::make_shared<spdlog::logger>("logger", begin(sinks), end(sinks));
     spdlog::register_logger(combined_logger);
 

--- a/Shared/CMakeLists.txt
+++ b/Shared/CMakeLists.txt
@@ -29,6 +29,7 @@ set(DEAMON_SHARED_SOURCE_FILES
         Sources/FocusAuthenticator.cpp
         Sources/FocusSocket.cpp
         Sources/FocusConfiguration.cpp
+        Sources/FocusPlatformFolders.cpp
 
         Headers/FocusDaemon.hpp
         Headers/FocusEventManager.hpp
@@ -41,6 +42,7 @@ set(DEAMON_SHARED_SOURCE_FILES
         Headers/FocusSocket.hpp
         Headers/FocusSecureSocket.hpp
         Headers/FocusConfiguration.hpp
+        Headers/FocusPlatformFolders.hpp
 
         Interfaces/IContextAgent.hpp
         Interfaces/IAfkListener.hpp

--- a/Shared/Headers/FocusConfiguration.hpp
+++ b/Shared/Headers/FocusConfiguration.hpp
@@ -35,6 +35,7 @@ private:
     struct server _defaultServer;
     std::string _configFile;
     std::string _source;
+    std::string _deviceName;
 public:
     FocusConfiguration(const std::string &configFile);
 
@@ -55,6 +56,8 @@ public:
     std::string getTriggerAfk() const;
 
     void generateConfigurationFile(const std::string &configFile);
+
+    const std::string &getDeviceName() const;
 };
 
 

--- a/Shared/Headers/FocusConfiguration.hpp
+++ b/Shared/Headers/FocusConfiguration.hpp
@@ -38,6 +38,8 @@ private:
 public:
     FocusConfiguration(const std::string &configFile);
 
+    void readConfiguration(const std::string &configFile, int attempt);
+
     bool isFilled() const;
 
     struct user getUser() const;
@@ -51,6 +53,8 @@ public:
     void setTriggerAfk(const std::string &triggerAfk);
 
     std::string getTriggerAfk() const;
+
+    void generateConfigurationFile(const std::string &configFile);
 };
 
 

--- a/Shared/Headers/FocusPlatformFolders.hpp
+++ b/Shared/Headers/FocusPlatformFolders.hpp
@@ -1,0 +1,170 @@
+/*
+Its is under the MIT license, to encourage reuse by cut-and-paste.
+The original files are hosted here: https://github.com/sago007/PlatformFolders
+Copyright (c) 2015 Poul Sander
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation files
+(the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef DAEMON_FOCUSPLATFORMFOLDERS_HPP
+#define DAEMON_FOCUSPLATFORMFOLDERS_HPP
+
+#include <vector>
+#include <string>
+
+/**
+ * The namespace I use for common function. Nothing special about it.
+ */
+namespace sago {
+
+/**
+ * Retrives the base folder for storring data files.
+ * You must add the program name yourself like this:
+ * @code{.cpp}
+ * string data_home = getDataHome()+"/My Program Name/";
+ * @endcode
+ * On Windows this defaults to %APPDATA% (Roaming profile)
+ * On Linux this defaults to ~/.local/share but can be configured
+ * @return The base folder for storring program data.
+ */
+    std::string getDataHome();
+/**
+ * Retrives the base folder for storring config files.
+ * You must add the program name yourself like this:
+ * @code{.cpp}
+ * string data_home = getConfigHome()+"/My Program Name/";
+ * @endcode
+ * On Windows this defaults to %APPDATA% (Roaming profile)
+ * On Linux this defaults to ~/.config but can be configured
+ * @return The base folder for storring config data.
+ */
+    std::string getConfigHome();
+/**
+ * Retrives the base folder for storring cache files.
+ * You must add the program name yourself like this:
+ * @code{.cpp}
+ * string data_home = getCacheDir()+"/My Program Name/";
+ * @endcode
+ * On Windows this defaults to %APPDATALOCAL%
+ * On Linux this defaults to ~/.cache but can be configured
+ * @return The base folder for storring data that do not need to be backed up.
+ */
+    std::string getCacheDir();
+/**
+ * This will append extra folders that your program should be looking for data files in.
+ * This does not normally include the path returned by GetDataHome().
+ * If you want all the folders you should do something like:
+ * @code{.cpp}
+ * vector<string> folders;
+ * folders.push_back(getDataHome());
+ * appendAdditionalDataDirectories(folders);
+ * for (string s& : folders) {
+ *     s+="/My Program Name/";
+ * }
+ * @endcode
+ * You must apply "/My Program Name/" to all the strings.
+ * The string at the lowest index has the highest priority.
+ * @param homes A vector that extra folders will be appended to.
+ */
+    void appendAdditionalDataDirectories(std::vector<std::string>& homes);
+/**
+ * This will append extra folders that your program should be looking for config files in.
+ * This does not normally include the path returned by GetConfigHome().
+ * If you want all the folders you should do something like:
+ * @code{.cpp}
+ * std::vector<std::string> folders;
+ * folders.push_back(sago::getConfigHome());
+ * sago::appendAdditionalConfigDirectories(folders);
+ * for (std::string s& : folders) {
+ *     s+="/My Program Name/";
+ * }
+ * @endcode
+ * You must apply "/My Program Name/" to all the strings.
+ * The string at the lowest index has the highest priority.
+ * @param homes A vector that extra folders will be appended to.
+ */
+    void appendAdditionalConfigDirectories(std::vector<std::string>& homes);
+
+/**
+ * This class contains methods for finding the system depended special folders.
+ * For Windows these folders are either by convention or given by CSIDL.
+ * For Linux XDG convention is used.
+ * The Linux version has very little error checking and assumes that the config is correct
+ */
+    class PlatformFolders {
+    public:
+        PlatformFolders();
+        ~PlatformFolders();
+        /**
+         * The folder that represents the desktop.
+         * Normally you should try not to use this folder.
+         * @return Absolute path to the user's desktop
+         */
+        std::string getDesktopFolder() const;
+        /**
+         * The folder to store user documents to
+         * @return Absolute path to the "Documents" folder
+         */
+        std::string getDocumentsFolder() const;
+        /**
+         * The folder for storring the user's pictures.
+         * @return Absolute path to the "Picture" folder
+         */
+        std::string getPicturesFolder() const;
+        /**
+         * The folder where files are downloaded.
+         * @note Windows: This version is XP compatible and returns the Desktop. Vista and later has a dedicated folder.
+         * @return Absolute path to the folder where files are downloaded to.
+         */
+        std::string getDownloadFolder1() const;
+        /**
+         * The folder where music is stored
+         * @return Absolute path to the music folder
+         */
+        std::string getMusicFolder() const;
+        /**
+         * The folder where video is stored
+         * @return Absolute path to the video folder
+         */
+        std::string getVideoFolder() const;
+        /**
+         * The base folder for storring saved games.
+         * You must add the program name to it like this:
+         * @code{.cpp}
+         * PlatformFolders pf;
+         * string saved_games_folder = pf.getSaveGamesFolder1()+"/My Program Name/";
+         * @endcode
+         * @note Windows: This is an XP compatible version and returns the path to "My Games" in Documents. Vista and later has an official folder.
+         * @note Linux: XDF does not define a folder for saved games. This will just return the same as GetDataHome()
+         * @return The folder base folder for storring save games.
+         */
+        std::string getSaveGamesFolder1() const;
+    private:
+        PlatformFolders(const PlatformFolders&);
+        PlatformFolders& operator=(const PlatformFolders&);
+#if defined(_WIN32)
+#elif defined(__APPLE__)
+#else
+        struct PlatformFoldersData;
+        PlatformFoldersData *data;
+#endif
+    };
+
+}  //namespace sago
+
+#endif //DAEMON_FOCUSPLATFORMFOLDERS_HPP

--- a/Shared/Sources/FocusConfiguration.cpp
+++ b/Shared/Sources/FocusConfiguration.cpp
@@ -35,32 +35,8 @@ FocusConfiguration::FocusConfiguration(const std::string &configFile) {
     _defaultServer._type = serverType::DEFAULT;
 
     _configFile = configFile;
-    lightconf::group config;
-    _source = "";
-    try {
-        spdlog::get("logger")->info("Loading configuration file from {0}", configFile);
-        std::ifstream stream(_configFile, std::ios::in);
-        if (stream) {
-            _source = std::string(std::istreambuf_iterator<char>(stream),
-                                  std::istreambuf_iterator<char>());
-            config = lightconf::config_format::read(_source);
-            _userInfo = config.get<user>("user");
-            _triggerAfk = config.get<std::string>("trigger_afk", "300");
-            _deviceId = config.get<std::string>("id_device", "");
-            _serversInfo = config.get<std::vector<server>>("servers", {});
-            _filled = true;
-            spdlog::get("logger")->info("Reading configuration file successfully");
-        } else {
-            _filled = false;
-            spdlog::get("logger")->error("Missing configuration file");
-        }
-    } catch (const lightconf::parse_error &e) {
-        _filled = false;
-        spdlog::get("logger")->error("Parsing configuration file error");
-    } catch (const std::exception &e) {
-        _filled = false;
-        spdlog::get("logger")->error("Failed to read configuration file");
-    }
+
+    readConfiguration(_configFile, 1);
 }
 
 bool FocusConfiguration::isFilled() const {
@@ -113,5 +89,81 @@ void FocusConfiguration::setTriggerAfk(const std::string &triggerAfk) {
             stream << lightconf::config_format::write(config, _source, 80);
             spdlog::get("logger")->info("triggerAfk id stored in configuration file");
         }
+    }
+}
+
+void FocusConfiguration::generateConfigurationFile(const std::string &configFile) {
+    auto askStdin = [] (std::string_view const &value) {
+        std::string in;
+        std::cout << value << ": ";
+        std::cin >> in;
+        return in;
+    };
+
+    spdlog::get("logger")->info("Generating a default configuration file");
+    lightconf::group config;
+    _source = "";
+    try {
+        config = lightconf::config_format::read(_source);
+        config.set<user>("user", user {
+                askStdin("First name"),
+                askStdin("Last name"),
+                askStdin("Email"),
+                askStdin("Password")
+        });
+        config.set<std::vector<server>>("servers", { server {
+                "auth.thefocuscompany.me", 3000, serverType::AUTHENTICATION
+        }, server {
+                "backend.thefocuscompany.me", 5555, serverType::BACKEND
+        }});
+        config.set<std::string>("trigger_afk", "300");
+        config.set<std::string>("id_device", "");
+
+        std::ofstream stream(configFile, std::ios::out);
+        if (stream) {
+            stream << lightconf::config_format::write(config, _source, 80);
+        } else {
+            spdlog::get("logger")->error("Unable to create config file");
+        }
+        spdlog::get("logger")->info("Written configuration file successfully");
+    } catch (const std::exception &e) {
+        spdlog::get("logger")->error("Failed to write configuration file");
+    }
+}
+
+void FocusConfiguration::readConfiguration(const std::string &configFile, int attempt) {
+    if (attempt > 3) {
+        spdlog::get("logger")->critical("Failed to generate a default configuration file after {0} attempt", attempt);
+        std::exit(1);
+    }
+
+    lightconf::group config;
+    _source = "";
+    try {
+        spdlog::get("logger")->info("Loading configuration file from {0}", configFile);
+        std::ifstream stream(_configFile, std::ios::in);
+        if (stream) {
+            _source = std::string(std::istreambuf_iterator<char>(stream),
+                                  std::istreambuf_iterator<char>());
+            config = lightconf::config_format::read(_source);
+            _userInfo = config.get<user>("user");
+            _triggerAfk = config.get<std::string>("trigger_afk", "300");
+            _deviceId = config.get<std::string>("id_device", "");
+            _serversInfo = config.get<std::vector<server>>("servers", {});
+            _filled = true;
+            spdlog::get("logger")->info("Reading configuration file successfully");
+        } else {
+            _filled = false;
+            spdlog::get("logger")->warn("Missing configuration file");
+            generateConfigurationFile(configFile);
+            readConfiguration(configFile, attempt++);
+
+        }
+    } catch (const lightconf::parse_error &e) {
+        _filled = false;
+        spdlog::get("logger")->error("Parsing configuration file error");
+    } catch (const std::exception &e) {
+        _filled = false;
+        spdlog::get("logger")->error("Failed to read configuration file");
     }
 }

--- a/Shared/Sources/FocusConfiguration.cpp
+++ b/Shared/Sources/FocusConfiguration.cpp
@@ -93,7 +93,7 @@ void FocusConfiguration::setTriggerAfk(const std::string &triggerAfk) {
 }
 
 void FocusConfiguration::generateConfigurationFile(const std::string &configFile) {
-    auto askStdin = [] (std::string_view const &value) {
+    auto askStdin = [] (std::string const &value) {
         std::string in;
         std::cout << value << ": ";
         std::cin >> in;

--- a/Shared/Sources/FocusConfiguration.cpp
+++ b/Shared/Sources/FocusConfiguration.cpp
@@ -9,6 +9,10 @@
 #include "lightconf/lightconf.hpp"
 #include "lightconf/config_format.hpp"
 
+#ifdef MSVC
+#include <Winsock2.h>
+#endif
+
 namespace lightconf {
     LIGHTCONF_BEGIN_ENUM(serverType)
                     LIGHTCONF_ENUM_VALUE(serverType::AUTHENTICATION, "AUTHENTICATION")

--- a/Shared/Sources/FocusConfiguration.cpp
+++ b/Shared/Sources/FocusConfiguration.cpp
@@ -38,6 +38,7 @@ FocusConfiguration::FocusConfiguration(const std::string &configFile) {
     lightconf::group config;
     _source = "";
     try {
+        spdlog::get("logger")->info("Loading configuration file from {0}", configFile);
         std::ifstream stream(_configFile, std::ios::in);
         if (stream) {
             _source = std::string(std::istreambuf_iterator<char>(stream),

--- a/Shared/Sources/FocusDaemon.cpp
+++ b/Shared/Sources/FocusDaemon.cpp
@@ -7,7 +7,7 @@
 #include <FocusPlatformFolders.hpp>
 
 void FocusDaemon::Run(const std::string &configFileName, std::atomic<bool> &sigReceived) {
-    auto dir = sago::getDataHome() + "/Focus/" + configFileName;
+    auto dir = sago::getConfigHome() + "/Focus/" + configFileName;
     spdlog::get("logger")->info("FocusDaemon is running");
     EventManager->Run(sigReceived);
     _config = std::make_shared<FocusConfiguration>(dir);

--- a/Shared/Sources/FocusDaemon.cpp
+++ b/Shared/Sources/FocusDaemon.cpp
@@ -4,11 +4,13 @@
 
 #include <FocusDaemon.hpp>
 #include <spdlog/spdlog.h>
+#include <FocusPlatformFolders.hpp>
 
 void FocusDaemon::Run(const std::string &configFileName, std::atomic<bool> &sigReceived) {
+    auto dir = sago::getDataHome() + "/Focus/" + configFileName;
     spdlog::get("logger")->info("FocusDaemon is running");
     EventManager->Run(sigReceived);
-    _config = std::make_shared<FocusConfiguration>(configFileName);
+    _config = std::make_shared<FocusConfiguration>(dir);
     auto usr = _config->getUser();
     Authenticator->Run(_config);
     if (Authenticator->Login(usr._email, usr._password, _config->getDeviceId())) {

--- a/Shared/Sources/FocusDaemon.cpp
+++ b/Shared/Sources/FocusDaemon.cpp
@@ -17,7 +17,7 @@ void FocusDaemon::Run(const std::string &configFileName, std::atomic<bool> &sigR
         _device_id = Authenticator->GetDeviceId();
         spdlog::get("logger")->info("User uuid: {}", Authenticator->GetUUID());
         if (_device_id.empty()) {
-            if (Authenticator->RegisterDevice("MacBook Pro de Etienne")) {
+            if (Authenticator->RegisterDevice(_config->getDeviceName())) {
                 Authenticator->Login(usr._email, usr._password, _config->getDeviceId());
                 _device_id = Authenticator->GetDeviceId();
             }

--- a/Shared/Sources/FocusPlatformFolders.cpp
+++ b/Shared/Sources/FocusPlatformFolders.cpp
@@ -1,0 +1,367 @@
+//
+// Created by Hippolyte Barraud on 5/2/18.
+//
+
+/*
+Its is under the MIT license, to encourage reuse by cut-and-paste.
+The original files are hosted here: https://github.com/sago007/PlatformFolders
+Copyright (c) 2015-2016 Poul Sander
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation files
+(the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "FocusPlatformFolders.hpp"
+#include <iostream>
+#include <stdexcept>
+#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+
+#if defined(_WIN32)
+#include <windows.h>
+#include <shlobj.h>
+
+static std::string win32_utf16_to_utf8(const wchar_t* wstr)
+{
+	std::string res;
+	// If the 6th parameter is 0 then WideCharToMultiByte returns the number of bytes needed to store the result.
+	int actualSize = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, NULL, 0, NULL, NULL);
+	if (actualSize > 0) {
+		//If the converted UTF-8 string could not be in the initial buffer. Allocate one that can hold it.
+		std::vector<char> buffer(actualSize);
+		actualSize = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, &buffer[0], buffer.size(), NULL, NULL);
+		res = buffer.data();
+	}
+	if (actualSize == 0) {
+		// WideCharToMultiByte return 0 for errors.
+		const std::string errorMsg = "UTF16 to UTF8 failed with error code: " + GetLastError();
+		throw std::runtime_error(errorMsg.c_str());
+	}
+	return res;
+}
+
+static std::string GetWindowsFolder(int folderId, const char* errorMsg) {
+	wchar_t szPath[MAX_PATH];
+	szPath[0] = 0;
+	if ( !SUCCEEDED( SHGetFolderPathW( NULL, folderId, NULL, 0, szPath ) ) )
+	{
+		throw std::runtime_error(errorMsg);
+	}
+	return win32_utf16_to_utf8(szPath);
+}
+
+static std::string GetAppData() {
+	return GetWindowsFolder(CSIDL_APPDATA, "RoamingAppData could not be found");
+}
+
+static std::string GetAppDataCommon() {
+	return GetWindowsFolder(CSIDL_COMMON_APPDATA, "Common appdata could not be found");
+}
+
+static std::string GetAppDataLocal() {
+	return GetWindowsFolder(CSIDL_LOCAL_APPDATA, "LocalAppData could not be found");
+}
+#elif defined(__APPLE__)
+#include <CoreServices/CoreServices.h>
+
+static std::string GetMacFolder(OSType folderType, const char* errorMsg) {
+	std::string ret;
+	FSRef ref;
+	char path[PATH_MAX];
+	OSStatus err = FSFindFolder( kUserDomain, folderType, kCreateFolder, &ref );
+	if (err != noErr) {
+		throw std::runtime_error(errorMsg);
+	}
+	FSRefMakePath( &ref, (UInt8*)&path, PATH_MAX );
+	ret = path;
+	return ret;
+}
+
+#else
+#include <map>
+#include <fstream>
+#include <pwd.h>
+#include <unistd.h>
+#include <sys/types.h>
+// For strlen and strtok
+#include <cstring>
+//Typically Linux. For easy reading the comments will just say Linux but should work with most *nixes
+
+static void throwOnRelative(const char* envName, const char* envValue) {
+    if (envValue[0] != '/') {
+        char buffer[200];
+        std::snprintf(buffer, sizeof(buffer), "Environment \"%s\" does not start with an '/'. XDG specifies that the value must be absolute. The current value is: \"%s\"", envName, envValue);
+        throw std::runtime_error(buffer);
+    }
+}
+
+/**
+ * Retrives the effective user's home dir.
+ * If the user is running as root we ignore the HOME environment. It works badly with sudo.
+ * Writing to $HOME as root implies security concerns that a multiplatform program cannot be assumed to handle.
+ * @return The home directory. HOME environment is respected for non-root users if it exists.
+ */
+static std::string getHome() {
+    std::string res;
+    int uid = getuid();
+    const char* homeEnv = std::getenv("HOME");
+    if ( uid != 0 && homeEnv) {
+        //We only acknowlegde HOME if not root.
+        res = homeEnv;
+        return res;
+    }
+    struct passwd *pw = getpwuid(uid);
+    if (!pw) {
+        throw std::runtime_error("Unable to get passwd struct.");
+    }
+    const char* tempRes = pw->pw_dir;
+    if (!tempRes) {
+        throw std::runtime_error("User has no home directory");
+    }
+    res = tempRes;
+    return res;
+}
+
+static std::string getLinuxFolderDefault(const char* envName, const char* defaultRelativePath) {
+    std::string res;
+    const char* tempRes = std::getenv(envName);
+    if (tempRes) {
+        throwOnRelative(envName, tempRes);
+        res = tempRes;
+        return res;
+    }
+    res = getHome() + "/" + defaultRelativePath;
+    return res;
+}
+
+static void appendExtraFoldersTokenizer(const char* envName, const char* envValue, std::vector<std::string>& folders) {
+    std::vector<char> buffer(envValue, envValue + std::strlen(envValue) + 1);
+    char* p = std::strtok ( &buffer[0], ":");
+    while (p != NULL) {
+        if (p[0] == '/') {
+            folders.push_back(p);
+        }
+        else {
+            //Unless the system is wrongly configured this should never happen... But of course some systems will be incorectly configured.
+            //The XDG documentation indicates that the folder should be ignored but that the program should continue.
+            std::cerr << "Skipping path \"" << p << "\" in \"" << envName << "\" because it does not start with a \"/\"\n";
+        }
+        p = std::strtok (NULL, ":");
+    }
+}
+
+static void appendExtraFolders(const char* envName, const char* defaultValue, std::vector<std::string>& folders) {
+    const char* envValue = std::getenv(envName);
+    if (!envValue) {
+        envValue = defaultValue;
+    }
+    appendExtraFoldersTokenizer(envName, envValue, folders);
+}
+
+#endif
+
+
+namespace sago {
+
+    std::string getDataHome() {
+#if defined(_WIN32)
+        return GetAppData();
+#elif defined(__APPLE__)
+        return GetMacFolder(kApplicationSupportFolderType, "Failed to find the Application Support Folder");
+#else
+        return getLinuxFolderDefault("XDG_DATA_HOME", ".local/share");
+#endif
+    }
+
+    std::string getConfigHome() {
+#if defined(_WIN32)
+        return GetAppData();
+#elif defined(__APPLE__)
+        return GetMacFolder(kApplicationSupportFolderType, "Failed to find the Application Support Folder");
+#else
+        return getLinuxFolderDefault("XDG_CONFIG_HOME", ".config");
+#endif
+    }
+
+    std::string getCacheDir() {
+#if defined(_WIN32)
+        return GetAppDataLocal();
+#elif defined(__APPLE__)
+        return GetMacFolder(kCachedDataFolderType, "Failed to find the Application Support Folder");
+#else
+        return getLinuxFolderDefault("XDG_CONFIG_HOME", ".cache");
+#endif
+    }
+
+    void appendAdditionalDataDirectories(std::vector<std::string>& homes) {
+#if defined(_WIN32)
+        homes.push_back(GetAppDataCommon());
+#elif defined(__APPLE__)
+#else
+        appendExtraFolders("XDG_DATA_DIRS", "/usr/local/share/:/usr/share/", homes);
+#endif
+    }
+
+    void appendAdditionalConfigDirectories(std::vector<std::string>& homes) {
+#if defined(_WIN32)
+        homes.push_back(GetAppDataCommon());
+#elif defined(__APPLE__)
+#else
+        appendExtraFolders("XDG_CONFIG_DIRS", "/etc/xdg", homes);
+#endif
+    }
+
+#if defined(_WIN32)
+#elif defined(__APPLE__)
+#else
+    struct PlatformFolders::PlatformFoldersData {
+        std::map<std::string, std::string> folders;
+    };
+
+    static void PlatformFoldersAddFromFile(const std::string& filename, std::map<std::string, std::string>& folders) {
+        std::ifstream infile(filename.c_str());
+        std::string line;
+        while (std::getline(infile, line)) {
+            if (line.length() == 0 || line.at(0) == '#') {
+                continue;
+            }
+            std::size_t splitPos = line.find("=");
+            std::string key = line.substr(0, splitPos);
+            std::string value = line.substr(splitPos+2, line.length()-splitPos-3);
+            folders[key] = value;
+            //std::cout << key << " : " << value << "\n";
+        }
+    }
+
+    static void PlatformFoldersFillData(std::map<std::string, std::string>& folders) {
+        folders["XDG_DOCUMENTS_DIR"] = "$HOME/Documents";
+        folders["XDG_DESKTOP_DIR"] = "$HOME/Desktop";
+        folders["XDG_DOWNLOAD_DIR"] = "$HOME/Downloads";
+        folders["XDG_MUSIC_DIR"] = "$HOME/Music";
+        folders["XDG_PICTURES_DIR"] = "$HOME/Pictures";
+        folders["XDG_PUBLICSHARE_DIR"] = "$HOME/Public";
+        folders["XDG_TEMPLATES_DIR"] = "$HOME/.Templates";
+        folders["XDG_VIDEOS_DIR"] = "$HOME/Videos";
+        PlatformFoldersAddFromFile( getConfigHome()+"/user-dirs.dirs", folders);
+        for (std::map<std::string, std::string>::iterator itr = folders.begin() ; itr != folders.end() ; ++itr ) {
+            std::string& value = itr->second;
+            if (value.compare(0, 5, "$HOME") == 0) {
+                value = getHome() + value.substr(5, std::string::npos);
+            }
+        }
+    }
+#endif
+
+    PlatformFolders::PlatformFolders() {
+#if defined(_WIN32)
+#elif defined(__APPLE__)
+#else
+        this->data = new PlatformFolders::PlatformFoldersData();
+        try {
+            PlatformFoldersFillData(data->folders);
+        } catch (...) {
+            delete this->data;
+            throw;
+        }
+#endif
+    }
+
+    PlatformFolders::~PlatformFolders() {
+#if defined(_WIN32)
+#elif defined(__APPLE__)
+#else
+        delete this->data;
+#endif
+    }
+
+    std::string PlatformFolders::getDocumentsFolder() const {
+#if defined(_WIN32)
+        return GetWindowsFolder(CSIDL_PERSONAL, "Failed to find My Documents folder");
+#elif defined(__APPLE__)
+        return GetMacFolder(kDocumentsFolderType, "Failed to find Documents Folder");
+#else
+        return data->folders["XDG_DOCUMENTS_DIR"];
+#endif
+    }
+
+    std::string PlatformFolders::getDesktopFolder() const {
+#if defined(_WIN32)
+        return GetWindowsFolder(CSIDL_DESKTOP, "Failed to find Desktop folder");
+#elif defined(__APPLE__)
+        return GetMacFolder(kDesktopFolderType, "Failed to find Desktop folder");
+#else
+        return data->folders["XDG_DESKTOP_DIR"];
+#endif
+    }
+
+    std::string PlatformFolders::getPicturesFolder() const {
+#if defined(_WIN32)
+        return GetWindowsFolder(CSIDL_MYPICTURES, "Failed to find My Pictures folder");
+#elif defined(__APPLE__)
+        return GetMacFolder(kPictureDocumentsFolderType, "Failed to find Picture folder");
+#else
+        return data->folders["XDG_PICTURES_DIR"];
+#endif
+    }
+
+    std::string PlatformFolders::getDownloadFolder1() const {
+#if defined(_WIN32)
+        //Pre Vista. Files was downloaded to the desktop
+	return GetWindowsFolder(CSIDL_DESKTOP, "Failed to find My Downloads (Desktop) folder");
+#elif defined(__APPLE__)
+        return GetMacFolder(kDownloadsFolderType, "Failed to find Download folder");
+#else
+        return data->folders["XDG_DOWNLOAD_DIR"];
+#endif
+    }
+
+    std::string PlatformFolders::getMusicFolder() const {
+#if defined(_WIN32)
+        return GetWindowsFolder(CSIDL_MYMUSIC, "Failed to find My Music folder");
+#elif defined(__APPLE__)
+        return GetMacFolder(kMusicDocumentsFolderType, "Failed to find Music folder");
+#else
+        return data->folders["XDG_MUSIC_DIR"];
+#endif
+    }
+
+    std::string PlatformFolders::getVideoFolder() const {
+#if defined(_WIN32)
+        return GetWindowsFolder(CSIDL_MYVIDEO, "Failed to find My Video folder");
+#elif defined(__APPLE__)
+        return GetMacFolder(kMovieDocumentsFolderType, "Failed to find Movie folder");
+#else
+        return data->folders["XDG_VIDEOS_DIR"];
+#endif
+    }
+
+    std::string PlatformFolders::getSaveGamesFolder1() const {
+#if defined(_WIN32)
+        //A dedicated Save Games folder was not introduced until Vista. For XP and older save games are most often saved in a normal folder named "My Games".
+	//Data that should not be user accessible should be placed under GetDataHome() instead
+	return GetWindowsFolder(CSIDL_PERSONAL, "Failed to find My Documents folder")+"\\My Games";
+#elif defined(__APPLE__)
+        return GetMacFolder(kApplicationSupportFolderType, "Failed to find Application Support Folder");
+#else
+        return getDataHome();
+#endif
+    }
+
+
+
+}  //namespace sago

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -9,6 +9,7 @@
 #include <spdlog/spdlog.h>
 #include "FocusDaemon.hpp"
 #include <condition_variable>
+#include <FocusPlatformFolders.hpp>
 
 std::mutex mtx;
 std::condition_variable cv;
@@ -41,7 +42,7 @@ int main(const int ac, const char** av)
 	auto console = spdlog::stdout_color_mt("console");
 	std::vector<spdlog::sink_ptr> sinks;
 	sinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_mt>());
-	sinks.push_back(std::make_shared<spdlog::sinks::rotating_file_sink_mt>("logs/logs.txt", 1048576 * 5, 3));
+	sinks.push_back(std::make_shared<spdlog::sinks::rotating_file_sink_mt>(sago::getDataHome() + "/Focus/logs.txt", 1048576 * 5, 3));
 	auto combined_logger = std::make_shared<spdlog::logger>("logger", begin(sinks), end(sinks));
 	spdlog::register_logger(combined_logger);
 


### PR DESCRIPTION
Logs and config now use platform-specific special folders.

This will need further work to work out-of-the-box. We'll need to provide/generate a default config file in the correct platform-specific location at first run/installation time, but this is out-of-scope.